### PR TITLE
Docker Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+**v2.2.0**
+
+- support docker registries as an alternative to S3
+- deprecated `dst_env_file`
+- added `sse_kms_key_id` for optional SSE-KMS on all porter uploads
+
+**v2.1.2**
+
+- increase logrotate size from 10M to 100M
+
 **v2.1.1**
 
 - fix ec2-bootstrap hook clone for multi-region deployment
@@ -27,6 +37,10 @@
 - CIS Linux 2014.09 benchmark remediation 9.2.13
 - CloudFormation templates are now uploaded to S3 to avoid the 51,200 byte limit
 - S3 keys are scoped under `porter-deployment` and `porter-template`
+
+**v1.0.6**
+
+- run the container as root (configurable with uid) to fix breaking change
 
 **v1.0.5**
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+v2.2
+====
+
+[Docker registries](docs/detailed_design/service-payload.md) are supported
+
+v2.1
+====
+
+It's now possible to deploy
+
+1. Worker containers in a inet topology (i.e. with an ELB)
+1. A worker-only CloudFormation stack (i.e. no ELB)
+1. More than container per EC2 host
+
+The the [topology config](docs/detailed_design/config-reference.md#topology) for
+notes and limitations
+
 v2
 ==
 

--- a/cfn_template/auto_scaling.go
+++ b/cfn_template/auto_scaling.go
@@ -40,6 +40,11 @@ type (
 		ServicePayloadKey        string
 		ServicePayloadConfigPath string
 
+		SecretsPayloadKey string
+
+		RegistryDeployment bool
+		InsecureRegistry   string
+
 		InetHealthCheckMethod string
 		InetHealthCheckPath   string
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -30,14 +30,23 @@ const (
 	CloudFormationTemplatePath = TempDir + "/CloudFormationTemplate.json"
 	EnvFile                    = "/dockerfile.env"
 
+	// Debug/config
 	EnvConfig                    = "DEBUG_CONFIG"
 	EnvDebugAws                  = "DEBUG_AWS"
 	EnvLogDebug                  = "LOG_DEBUG"
 	EnvStackCreation             = "STACK_CREATION_TIMEOUT"
 	EnvStackCreationPollInterval = "STACK_CREATION_POLL_INTERVAL"
-	EnvNoDockerOverride          = "NO_DOCKER_OVERRIDE"
 	EnvNoLogColor                = "NO_LOG_COLOR"
 	EnvDevMode                   = "DEV_MODE"
+
+	// Registry-based deployment
+	EnvDockerRegistry         = "DOCKER_REGISTRY"
+	EnvDockerInsecureRegistry = "DOCKER_INSECURE_REGISTRY"
+	EnvDockerRepository       = "DOCKER_REPOSITORY"
+	EnvDockerPullUsername     = "DOCKER_PULL_USERNAME"
+	EnvDockerPullPassword     = "DOCKER_PULL_PASSWORD"
+	EnvDockerPushUsername     = "DOCKER_PUSH_USERNAME"
+	EnvDockerPushPassword     = "DOCKER_PUSH_PASSWORD"
 
 	HookPrePack       = "pre_pack"
 	HookPostPack      = "post_pack"
@@ -115,8 +124,6 @@ const (
 	// A key in resource metadata to tag security groups that should be
 	// associated with a AWS::AutoScaling::LaunchConfiguration
 	MetadataAsLc = "as-lc-sg"
-
-	MetadataAsEnvFiles = "env_files"
 
 	ElbSgLogicalName = "InetToElb"
 

--- a/docs/detailed_design/config-reference.md
+++ b/docs/detailed_design/config-reference.md
@@ -28,6 +28,7 @@ For each field the following notation is used
     - [hosted_zone_name](#hosted_zone_name) (==1?)
     - [key_pair_name](#key_pair_name) (==1?)
     - [s3_bucket](#s3_bucket) (==1!)
+    - [sse_kms_key_id](#sse_kms_key_id) (==1!)
     - [elb](#elb) (==1?)
     - [azs](#azs) (>=1!)
       - name
@@ -42,7 +43,6 @@ For each field the following notation is used
       - [read_only](#read_only) (==1?)
       - [health_check](#health_check) (==1?)
       - [src_env_file](#src_env_file) (==1?)
-      - [dst_env_file](#dst_env_file) (==1?)
 - [hooks](#hooks) (==1?)
   - pre_pack (==1?)
     - [repo](#repo) (==1!)
@@ -262,6 +262,11 @@ instances.
 
 The bucket used by porter to upload builds into.
 
+### sse_kms_key_id
+
+The ARN of a KMS key for use with SSE-KMS. If defined all uploads to the
+`s3_bucket` will be encrypted with this key.
+
 ### vpc_id
 
 The VPC id needed to create security groups
@@ -390,11 +395,6 @@ health_check:
 ```
 
 ### src_env_file
-
-See the docs on [container config](container-config.md) for more info on this
-field
-
-### dst_env_file
 
 See the docs on [container config](container-config.md) for more info on this
 field

--- a/docs/detailed_design/container-config.md
+++ b/docs/detailed_design/container-config.md
@@ -39,7 +39,6 @@ Source 1: S3 w/ SSE-KMS
 Assuming the existence of
 
 1. A S3 bucket to place secrets in called `secrets-src-bucket`
-1. A S3 bucket to copy secrets into called `secrets-dst-bucket`. The source and destination can be the same bucket.
 1. A KMS key with the ARN `arn:aws:kms:us-east-1:123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee`
 
 Upload `secrets.env-file` to the source bucket, and encrypt it with a KMS key.
@@ -59,7 +58,7 @@ aws s3api put-object \
 
 ### Configure the container
 
-In `.porter/config` set the `src_env_file` and `dst_env_file` properties
+In `.porter/config` set the `src_env_file` properties
 
 ```yaml
 environments:
@@ -71,50 +70,10 @@ environments:
       src_env_file:
         s3_bucket: secrets-src-bucket
         s3_key: secrets.env-file
-      dst_env_file:
-        s3_bucket: secrets-dst-bucket
-        kms_arn: arn:aws:kms:us-east-1:123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
 ```
 
-Note: `dst_env_file.kms_arn` is optional but there for convenience so SSE-KMS
-can be used throughout the entire flow.
-
-### Aside: multi-region deployments
-
-SSE-KMS ties a S3 bucket to a KMS key per region so the following config is
-common for multi-region deployments where the source for secrets is central and
-they're copied to S3 buckets in the regions to which a service will be deployed.
-
-Here is an example config that deploys to 2 regions (us-west-2 and us-east-1),
-keeps secrets in the us-east-1 bucket, and encrypts the destination with SSE-KMS.
-
-Yaml aliases make it easy to factor out the common config.
-
-```yaml
-_container_base_definition: &CONTAINER_BASE
-  topology: inet
-  src_env_file:
-    s3_bucket: secrets-src-bucket-us-east-1
-    s3_key: secrets.env-file
-
-environments:
-- name: prod
-
-  regions:
-  - name: us-east-1
-    containers:
-    - <<: *CONTAINER_BASE
-      dst_env_file:
-        s3_bucket: secrets-dst-bucket-us-east-1
-        kms_arn: arn:aws:kms:us-east-1:123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
-
-  - name: us-west-2
-    containers:
-    - <<: *CONTAINER_BASE
-      dst_env_file:
-        s3_bucket: secrets-dst-bucket-us-west-2
-        kms_arn: arn:aws:kms:us-west-2:123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeef
-```
+That's it. Porter has the information it needs to download secrets for the
+container.
 
 Source 2: DIY secrets
 ---------------------
@@ -147,13 +106,11 @@ environments:
         exec_args:
         - -region
         - us-west-2
-      dst_env_file:
-        s3_bucket: secrets-dst-bucket
-        kms_arn: arn:aws:kms:us-west-2:123456789012:key/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeef
 ```
 
 Porter calls [`os/exec.Command()`](https://golang.org/pkg/os/exec/#Command) with
-`exec_name` and `exec_args`.
+`exec_name` and `exec_args`, captures the executable's stdout, and cleans
+comments/whitespace.
 
 Destination: S3 and EC2 initialization
 --------------------------------------
@@ -177,9 +134,9 @@ disk.
    The output of NewGCM is a AEAD interface which porter then calls Seal() on to
    create an encrypted byte array ("Encrypted Secrets")
 1. Porter running on the Build Box provisions infrastructure by
-  1. Uploading the Encrypted Secrets to a configurable S3 bucket
-     (`dst_env_file.s3_bucket`). The S3 key is a MD5 digest of Encrypted
-     Secrets. Together the bucket and key are the "S3 Location".
+  1. Uploading the Encrypted Secrets to the region's
+     [S3 bucket](config-reference.md#s3_bucket). The S3 key is a MD5 digest of
+     Encrypted Secrets. Together the bucket and key are the "S3 Location".
   1. Creating a CloudFormation Template ("the Template")
   1. Calling CloudFormation:CreateStack with
     1. The Template that has baked into it the S3 Location of Encrypted Secrets
@@ -211,14 +168,10 @@ Summary
 Porter provides light integration with S3 to source secrets. It also provides a
 way to plugin your own secrets by calling into your own tool.
 
-The configuration both flows require is `dst_env_file.s3_bucket`
-
-`dst_env_file.kms_arn` is optionally configurable as an extra layer of protection.
-
-Regardless of the use of SSE-KMS, porter does its own encryption of secrets in
-transit, and separates the lock (encrypted payload in S3) from the key
-(hex-encoded 256 bit key in a CloudFormation parameter). Under this scheme both
-services would need to be compromised.
+Porter does its own encryption of secrets in transit, and separates the lock
+(encrypted payload in S3) from the key (hex-encoded 256 bit key in a
+CloudFormation parameter). Under this scheme both services would need to be
+compromised.
 
 Obviously if the build box where secrets were first accessed, or the EC2 host
 where porter and any other process have access to the lock and key, are
@@ -239,10 +192,11 @@ Consider the following scenario:
 1. EC2 instance initializes and pulls `secrets.env-file`
 1. The EC2 instance now has version B of the env-file, not the one it was deployed with
 
-To avoid this scenario (which also happens during a scale out) porter does a MD5
-"fingerprint" of the encrypted secrets and copies them to a destination S3
-bucket. The copy and fingerprint ensure that the failed instance in step 4
-comes back online with the correct version of the secrets file.
+To avoid this scenario (which also happens during a scale out) porter uses the
+MD5 "fingerprint" of the service payload and copies the encrypted secrets to the
+same location as the [service payload](service-payload.md). The copy and
+fingerprint ensure that the failed instance in step 4 comes back online with the
+correct version of the secrets file.
 
 Resources
 ---------

--- a/docs/detailed_design/service-payload.md
+++ b/docs/detailed_design/service-payload.md
@@ -1,0 +1,38 @@
+Service payload
+===============
+
+The service payload by default is a compressed tarball containing a modified
+`.porter/config` and the output of `docker save -o` for each container defined.
+
+This is multipart uploaded to S3 with the following key
+
+```
+porter-deployment/{service name}/{environment}/{git rev-parse --short HEAD}/{md5 of tarball}.tar
+```
+
+Docker registry
+---------------
+
+Alternatively a docker registry can be used for docker images. With this
+configuration the S3 payload only contains the modified `.porter/config`.
+
+Registry-based deployments are configured outside of `.porter/config` with
+environment variables.
+
+`DOCKER_REGISTRY` is the hostname of the registry excluding the `http://` or
+`https://` prefixes
+
+`DOCKER_REPOSITORY` is the repository name
+
+`DOCKER_PUSH_USERNAME` and `DOCKER_PUSH_PASSWORD`, if defined, will be used to
+perform `docker login` before doing a `docker push`. Otherwise `docker login`
+will be skipped.
+
+`DOCKER_PULL_USERNAME` and `DOCKER_PULL_PASSWORD`, if defined, will be used to
+perform `docker login` before running containers on a EC2 host. Otherwise
+`docker login` will be skipped. These credentials are placed in the same secrets
+payload as [container config](container-config.md).
+
+Set `DOCKER_INSECURE_REGISTRY=1` if you're using a registry with self-signed
+certs and porter will add `--insecure-registry=$DOCKER_REGISTRY` to the EC2
+host's docker daemon config.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -17,7 +17,10 @@ to call them.
   - [Container runtime config (including secrets)](detailed_design/container-config.md)
   - [Platform-Service interface](detailed_design/platform-service.md)
 - Deployment
-  - [Deployment flow](https://www.lucidchart.com/documents/view/95a3fdca-ff76-40c5-98fd-6b3071ba86bc)
+  - Diagrams
+    - [Flow](https://www.lucidchart.com/documents/view/95a3fdca-ff76-40c5-98fd-6b3071ba86bc)
+    - [Steady state](https://cloudcraft.co/view/b28b95ec-19c1-4d69-9f3d-cdccc9ddc2f2?key=DuedC3Bnjqoda_LVPniJDA)
+  - [Service payload (S3 and Docker registry)](detailed_design/service-payload.md)
   - [CI/CD integration](detailed_design/ci-cd-integration.md)
   - [Deployment customization](detailed_design/deployment-hooks.md)
 - Infrastructure

--- a/files/porter_bootstrap
+++ b/files/porter_bootstrap
@@ -18,6 +18,9 @@ adduser porter-docker -u {{ .ContainerUserUid }}
 echo 'OPTIONS="$OPTIONS --disable-legacy-registry"' >> /etc/sysconfig/docker
 # CIS Docker Benchmark 1.11.0 2.1
 echo 'OPTIONS="$OPTIONS --icc=false"' >> /etc/sysconfig/docker
+{{ if .InsecureRegistry -}}
+echo 'OPTIONS="$OPTIONS --insecure-registry={{ .InsecureRegistry }}"' >> /etc/sysconfig/docker
+{{ end -}}
 service haproxy start
 service docker restart
 docker version

--- a/files/porter_hotswap
+++ b/files/porter_hotswap
@@ -1,15 +1,21 @@
+{{ if .LogDebug -}}
+export LOG_DEBUG=1
+{{- end }}
+
 echo "downloading service payload"
 aws s3 cp s3://{{ .ServicePayloadBucket }}/{{ .ServicePayloadKey }} payload.tar
 
+{{ if not .RegistryDeployment -}}
 # load all the containers in this tar
 echo "loading containers"
 {{ range $imageName := .ImageNames -}}
 tar -xOf payload.tar ./{{ $imageName }}.docker | docker load
 {{ end -}}
+{{ end -}}
 
 echo "starting containers"
 tar -xOf payload.tar ./{{ .ServicePayloadConfigPath }} \
-| porter host docker --start -e {{ .Environment }} -r {{ .Region }} \
+| porter host docker --start -e {{ .Environment }} -r {{ .Region }} -s {{ .SecretsPayloadKey }} \
 | porter host haproxy -sn {{ .ServiceName }}
 
 echo "cleaning containers"

--- a/promote/promote.go
+++ b/promote/promote.go
@@ -43,11 +43,9 @@ func Promote(log log15.Logger, config *conf.Config, provisionedEnv *provision_ou
 	}
 
 	for i := 0; i < stackCount; i++ {
-		select {
-		case promoteSuccess := <-promoteServiceChan:
-			if !promoteSuccess {
-				return
-			}
+		promoteSuccess := <-promoteServiceChan
+		if !promoteSuccess {
+			return
 		}
 	}
 

--- a/provision/api.go
+++ b/provision/api.go
@@ -12,8 +12,6 @@
 package provision
 
 import (
-	"encoding/json"
-	"os"
 	"sync"
 	"time"
 
@@ -38,10 +36,6 @@ type (
 		Region      string
 		SecretsKey  string
 		TemplateUrl string
-	}
-
-	PackOutput struct {
-		SHA string
 	}
 
 	CreateStackOutput struct {
@@ -146,24 +140,6 @@ func createUpdateStack(
 		return
 	}
 
-	packOutput := PackOutput{}
-
-	packOutputFile, err := os.Open(constants.PackOutputPath)
-	if err != nil {
-		log.Error("os.Open", "Path", constants.PackOutputPath, "Error", err)
-		return
-	}
-
-	if err := json.NewDecoder(packOutputFile).Decode(&packOutput); err != nil {
-		log.Error("json.NewDecoder", "Error", err)
-		return
-	}
-
-	if packOutput.SHA == "" {
-		log.Error("Missing SHA in pack output")
-		return
-	}
-
 	regionCount := len(environment.Regions)
 
 	regionOutputs := make(map[string]CreateStackRegionOutput)
@@ -183,8 +159,6 @@ func createUpdateStack(
 		recv := &stackCreator{
 			log:  log.New("Region", region.Name),
 			args: args,
-
-			serviceVersion: packOutput.SHA,
 
 			stackName: stackName,
 

--- a/provision/map_resource.go
+++ b/provision/map_resource.go
@@ -409,7 +409,7 @@ func setAutoScalingLaunchConfigurationMetadata(recv *stackCreator, template *cfn
 		EnvFile:       constants.EnvFile,
 
 		ServiceName:    recv.config.ServiceName,
-		ServiceVersion: recv.serviceVersion,
+		ServiceVersion: recv.config.ServiceVersion,
 
 		EC2BootstrapScript: eC2BootstrapScript.String(),
 
@@ -418,6 +418,10 @@ func setAutoScalingLaunchConfigurationMetadata(recv *stackCreator, template *cfn
 		ServicePayloadBucket:     recv.region.S3Bucket,
 		ServicePayloadKey:        recv.servicePayloadKey,
 		ServicePayloadConfigPath: constants.ServicePayloadConfigPath,
+
+		SecretsPayloadKey: recv.secretPayloadKey,
+
+		RegistryDeployment: recv.registryDeployment,
 
 		InetHealthCheckMethod: strconv.Quote(recv.region.HealthCheckMethod()),
 		InetHealthCheckPath:   strconv.Quote(recv.region.HealthCheckPath()),
@@ -428,6 +432,10 @@ func setAutoScalingLaunchConfigurationMetadata(recv *stackCreator, template *cfn
 		LogDebug: os.Getenv(constants.EnvLogDebug) != "",
 
 		ContainerUserUid: constants.ContainerUserUid,
+	}
+
+	if os.Getenv(constants.EnvDockerInsecureRegistry) != "" {
+		cfnInitContext.InsecureRegistry = os.Getenv(constants.EnvDockerRegistry)
 	}
 
 	for _, container := range recv.region.Containers {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -9,6 +9,13 @@ import (
 
 const AesBytes = 32
 
+type Payload struct {
+	ContainerSecrets   map[string]string
+	DockerRegistry     string
+	DockerPullUsername string
+	DockerPullPassword string
+}
+
 func GenerateKey() (symmetricKey []byte, err error) {
 	symmetricKey = make([]byte, AesBytes)
 	_, err = rand.Read(symmetricKey)

--- a/testintegration/.porter/config
+++ b/testintegration/.porter/config
@@ -98,16 +98,12 @@ environments:
         exec_name: cat
         exec_args:
         - secrets.env-file
-      dst_env_file:
-        s3_bucket: porter-sandbox-us-west-2
     - <<: *CONTAINER_BASE_INET
       name: inet2
       src_env_file:
         exec_name: cat
         exec_args:
         - secrets.env-file
-      dst_env_file:
-        s3_bucket: porter-sandbox-us-west-2
     - <<: *CONTAINER_BASE_WORKER
       read_only: false
     - <<: *CONTAINER_BASE_WORKER
@@ -165,8 +161,6 @@ environments:
         s3_bucket: porter-sandbox-us-west-2
         s3_key: env-file
         s3_region: us-west-2
-      dst_env_file:
-        s3_bucket: porter-sandbox-us-west-2
     - <<: *CONTAINER_BASE_WORKER
     - <<: *CONTAINER_BASE_WORKER
       name: worker2

--- a/testintegration/GoCD.json
+++ b/testintegration/GoCD.json
@@ -1108,7 +1108,7 @@
               [
                 "#cloud-config\n",
                 "repo_upgrade: security\n",
-                "repo_releasever: 2015.03\n",
+                "repo_releasever: 2016.03\n",
                 "\n",
                 "packages:\n",
                 "  - git-daemon\n",
@@ -1333,11 +1333,11 @@
               [
                 "#cloud-config\n",
                 "repo_upgrade: security\n",
-                "repo_releasever: 2015.03\n",
+                "repo_releasever: 2016.03\n",
                 "\n",
                 "packages:\n",
                 "  - git\n",
-                "  - docker\n",
+                "  - docker-1.11.2\n",
                 "\n",
                 "runcmd:\n",
                 "  - echo running cfn-init -c cfnAgentStep0,cfnAgentStep1,cfnAgentStep2\n",


### PR DESCRIPTION
## Changelog
- support docker registries as an alternative to S3
- deprecated `dst_env_file`
- added `sse_kms_key_id` for optional SSE-KMS on all porter uploads
## Issues fixed or closed

Closes #18 
## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?
- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?
- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?
- [x] Yes
- [ ] N/A
