### PR TITLE
Run post hooks even if the pre hooks fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+**v2.4.3**
+
+- reject config files with `run_condition` set in a pre- hook
+- run post- hooks with `run_condition` set to `fail` when a pre- hook fails
+
 **v2.4.2**
 
 - fix missing or incomplete hook logs

--- a/commands/build/promote.go
+++ b/commands/build/promote.go
@@ -94,17 +94,17 @@ func (recv *PromoteCmd) Execute(args []string) bool {
 		os.Exit(1)
 	}
 
-	if !hook.Execute(log, constants.HookPrePromote,
-		provisionedEnv.Environment, provisionedEnv.Regions, true) {
-		os.Exit(1)
+	commandSuccess := hook.Execute(log, constants.HookPrePromote,
+		provisionedEnv.Environment, provisionedEnv.Regions, true)
+
+	if commandSuccess {
+		commandSuccess = promote.Promote(log, config, provisionedEnv, elbType)
 	}
 
-	commandSuccess := promote.Promote(log, config, provisionedEnv, elbType)
-
-	hookSuccess := hook.Execute(log, constants.HookPostPromote,
+	commandSuccess = hook.Execute(log, constants.HookPostPromote,
 		provisionedEnv.Environment, provisionedEnv.Regions, commandSuccess)
 
-	if !commandSuccess || !hookSuccess {
+	if !commandSuccess {
 		os.Exit(1)
 	}
 

--- a/commands/build/provision.go
+++ b/commands/build/provision.go
@@ -118,73 +118,72 @@ func ProvisionStack(env string) {
 		Environment: env,
 	}
 
-	if !hook.Execute(log, constants.HookPreProvision, env, nil, true) {
-		os.Exit(1)
-	}
-
-	stackOutput, success := provision.CreateStack(log, config, stackArgs)
-	if !success {
-		os.Exit(1)
-	}
-
-	regionCount := len(environment.Regions)
-	outputChan := make(chan provision_output.Region, regionCount)
-	failureChan := make(chan struct{}, regionCount)
-
-	for _, regionOutput := range stackOutput.Regions {
-		go provisionStackPoll(environment, regionOutput, outputChan, failureChan)
-	}
-
-	commandSuccess := true
-	for i := 0; i < regionCount; i++ {
-		select {
-		case regionOutput := <-outputChan:
-			provisionOutput.Regions = append(provisionOutput.Regions, regionOutput)
-		case _ = <-failureChan:
-			commandSuccess = false
-		}
-	}
+	commandSuccess := hook.Execute(log, constants.HookPreProvision, env, nil, true)
 
 	if commandSuccess {
-
-		provisionBytes, err := json.Marshal(provisionOutput)
-		if err != nil {
-			log.Error("json.Marshal", "Error", err)
+		stackOutput, success := provision.CreateStack(log, config, stackArgs)
+		if !success {
 			os.Exit(1)
 		}
 
-		// write the stackoutput into porter tmp directory
-		err = ioutil.WriteFile(constants.ProvisionOutputPath, provisionBytes, 0644)
-		if err != nil {
-			log.Error("Unable to write provision output", "Error", err)
-			os.Exit(1)
+		regionCount := len(environment.Regions)
+		outputChan := make(chan provision_output.Region, regionCount)
+		failureChan := make(chan struct{}, regionCount)
+
+		for _, regionOutput := range stackOutput.Regions {
+			go provisionStackPoll(environment, regionOutput, outputChan, failureChan)
 		}
 
-	} else {
+		for i := 0; i < regionCount; i++ {
+			select {
+			case regionOutput := <-outputChan:
+				provisionOutput.Regions = append(provisionOutput.Regions, regionOutput)
+			case _ = <-failureChan:
+				commandSuccess = false
+			}
+		}
 
-		if len(provisionOutput.Regions) > 0 {
-			log.Warn("Some regions failed to create. Deleting the successful ones")
+		if commandSuccess {
 
-			for _, pr := range provisionOutput.Regions {
-				roleARN, err := environment.GetRoleARN(pr.AWSRegion)
-				if err != nil {
-					log.Error("GetRoleARN", "Error", err)
-					continue
+			provisionBytes, err := json.Marshal(provisionOutput)
+			if err != nil {
+				log.Error("json.Marshal", "Error", err)
+				os.Exit(1)
+			}
+
+			// write the stackoutput into porter tmp directory
+			err = ioutil.WriteFile(constants.ProvisionOutputPath, provisionBytes, 0644)
+			if err != nil {
+				log.Error("Unable to write provision output", "Error", err)
+				os.Exit(1)
+			}
+
+		} else {
+
+			if len(provisionOutput.Regions) > 0 {
+				log.Warn("Some regions failed to create. Deleting the successful ones")
+
+				for _, pr := range provisionOutput.Regions {
+					roleARN, err := environment.GetRoleARN(pr.AWSRegion)
+					if err != nil {
+						log.Error("GetRoleARN", "Error", err)
+						continue
+					}
+
+					roleSession := aws_session.STS(pr.AWSRegion, roleARN, 0)
+					cfnClient := cloudformation.New(roleSession)
+
+					log.Info("DeleteStack", "StackId", pr.StackId)
+					cloudformation.DeleteStack(cfnClient, pr.StackId)
 				}
-
-				roleSession := aws_session.STS(pr.AWSRegion, roleARN, 0)
-				cfnClient := cloudformation.New(roleSession)
-
-				log.Info("DeleteStack", "StackId", pr.StackId)
-				cloudformation.DeleteStack(cfnClient, pr.StackId)
 			}
 		}
 	}
 
-	hookSuccess := hook.Execute(log, constants.HookPostProvision,
+	commandSuccess = hook.Execute(log, constants.HookPostProvision,
 		env, provisionOutput.Regions, commandSuccess)
 
-	if !commandSuccess || !hookSuccess {
+	if !commandSuccess {
 		os.Exit(1)
 	}
 }

--- a/commands/build/provision.go
+++ b/commands/build/provision.go
@@ -120,7 +120,10 @@ func ProvisionStack(env string) {
 
 	commandSuccess := hook.Execute(log, constants.HookPreProvision, env, nil, true)
 
-	if commandSuccess {
+	if !commandSuccess {
+		commandSuccess = hook.Execute(log, constants.HookPostProvision, env, nil, commandSuccess)
+
+	} else {
 		stackOutput, success := provision.CreateStack(log, config, stackArgs)
 		if !success {
 			os.Exit(1)
@@ -178,10 +181,11 @@ func ProvisionStack(env string) {
 				}
 			}
 		}
-	}
 
-	commandSuccess = hook.Execute(log, constants.HookPostProvision,
-		env, provisionOutput.Regions, commandSuccess)
+		commandSuccess = hook.Execute(log, constants.HookPostProvision,
+			env, provisionOutput.Regions, commandSuccess)
+
+	}
 
 	if !commandSuccess {
 		os.Exit(1)

--- a/commands/build/prune.go
+++ b/commands/build/prune.go
@@ -112,17 +112,17 @@ func (recv *PruneCmd) Execute(args []string) bool {
 		os.Exit(1)
 	}
 
-	if !hook.Execute(log, constants.HookPrePrune,
-		provisionedEnv.Environment, provisionedEnv.Regions, true) {
-		os.Exit(1)
+	commandSuccess := hook.Execute(log, constants.HookPrePrune,
+		provisionedEnv.Environment, provisionedEnv.Regions, true)
+
+	if commandSuccess {
+		commandSuccess = prune.Do(log, config, env, keepCount, true, elbTag)
 	}
 
-	commandSuccess := prune.Do(log, config, env, keepCount, true, elbTag)
-
-	hookSuccess := hook.Execute(log, constants.HookPostPrune,
+	commandSuccess = hook.Execute(log, constants.HookPostPrune,
 		provisionedEnv.Environment, provisionedEnv.Regions, commandSuccess)
 
-	if !commandSuccess || !hookSuccess {
+	if !commandSuccess {
 		os.Exit(1)
 	}
 

--- a/conf/validate.go
+++ b/conf/validate.go
@@ -112,6 +112,17 @@ func (recv *Config) ValidateHooks() (err error) {
 
 		for _, hook := range hookList {
 
+			switch name {
+			case constants.HookPostProvision:
+			case constants.HookPostPack:
+			case constants.HookPostPromote:
+			case constants.HookPostPrune:
+			default:
+				if hook.RunCondition != constants.HRC_Pass {
+					return fmt.Errorf("A run_condition option is not valid for a %s hook", name)
+				}
+			}
+
 			switch hook.RunCondition {
 			case constants.HRC_Pass:
 			case constants.HRC_Fail:


### PR DESCRIPTION
## Changelog
- reject config files with `run_condition` set in a pre- hook
- run post- hooks with `run_condition` set to `fail` when a pre- hook fails
## Issues fixed or closed
## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?
- [X] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?
- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?
- [x] Yes
- [ ] N/A

The intent of `run_condition: fail` is allow a `post_` hook to be called after any failure in the phase.

This change extends “failure in the phase” to include a failure in a `pre_` hook.  Previously, a `pre_` hook failure would be a short-circuit to error exit.
