### PR TITLE
Hotswap and ASG matching stack state fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### v3.0.2
 
+- additional UPDATE steady states allow ASG matching
+- any UPDATE in progress state causes hot swap to fail
 - mac binaries are now built with Go 1.7.3
 - match currently promoted stack's ASG size for provisioning and hot swap
 

--- a/commands/build/provision.go
+++ b/commands/build/provision.go
@@ -157,34 +157,12 @@ func ProvisionOrHotswapStack(env string) (success bool) {
 				case cfn.CREATE_COMPLETE, cfn.UPDATE_COMPLETE:
 					// only states eligible for hot swap
 
-				case cfn.CREATE_FAILED,
-					cfn.DELETE_COMPLETE,
-					cfn.DELETE_FAILED,
-					cfn.DELETE_IN_PROGRESS,
-					cfn.ROLLBACK_COMPLETE,
-					cfn.ROLLBACK_FAILED,
-					cfn.ROLLBACK_IN_PROGRESS:
-
-					hotswapData.shouldHotswap = false
-
-				case cfn.CREATE_IN_PROGRESS:
-
-					log.Error("Can't hot swap a stack being created")
-					return
-
 				case cfn.UPDATE_COMPLETE_CLEANUP_IN_PROGRESS,
-					cfn.UPDATE_IN_PROGRESS:
-
-					log.Error("A previous hot swap is still in progress",
-						"StackStatus", hotswapData.stackStatus)
-					return
-
-				case cfn.UPDATE_ROLLBACK_COMPLETE,
+					cfn.UPDATE_IN_PROGRESS,
 					cfn.UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS,
-					cfn.UPDATE_ROLLBACK_FAILED,
 					cfn.UPDATE_ROLLBACK_IN_PROGRESS:
 
-					log.Error("A previous hot swap appears to have failed",
+					log.Error("A previous hot swap is still in progress",
 						"StackStatus", hotswapData.stackStatus)
 					return
 

--- a/provision/stack_creator.go
+++ b/provision/stack_creator.go
@@ -211,7 +211,8 @@ tagLoop:
 	switch stackStatus {
 	case cfn.CREATE_COMPLETE,
 		cfn.UPDATE_COMPLETE,
-		cfn.UPDATE_ROLLBACK_COMPLETE:
+		cfn.UPDATE_ROLLBACK_COMPLETE,
+		cfn.UPDATE_ROLLBACK_FAILED:
 
 	// error cases that should cause a failure
 	case cfn.CREATE_IN_PROGRESS,


### PR DESCRIPTION
- additional UPDATE steady states allow ASG matching
- any UPDATE in progress state causes hot swap to fail
