### PR TITLE
Security group management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v3.0.5
+
+- add `autowire_security_groups` so security group management can be turned off
+
 ### v3.0.4
 
 - fixed issue with region-concurrent cleanup of service payload

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -99,6 +99,12 @@ type (
 		InstanceType        string           `yaml:"instance_type"`
 		BlackoutWindows     []BlackoutWindow `yaml:"blackout_windows"`
 		Regions             []*Region        `yaml:"regions"`
+
+		// From the client's perspective this relates to SG creation and ELB
+		// inspection that allows the 2 ELBs to communicate with EC2 instances.
+		// From porter's perspective this is just a signal to create them so
+		// further transformations can happen
+		CreateSecurityGroups *bool `yaml:"autowire_security_groups"`
 	}
 
 	BlackoutWindow struct {

--- a/daemon/identity/identity.go
+++ b/daemon/identity/identity.go
@@ -78,6 +78,7 @@ func populateInstanceIdentity(log log15.Logger) error {
 		log.Error("Error on instanceIdResp", "Error", err)
 		return err
 	}
+	defer instanceIdResp.Body.Close()
 
 	//Get AWS Region
 	awsRegionResp, err := http.Get(constants.EC2MetadataURL + "/placement/availability-zone")
@@ -85,20 +86,19 @@ func populateInstanceIdentity(log log15.Logger) error {
 		log.Error("Error on awsRegionResp", "Error", err)
 		return err
 	}
+	defer awsRegionResp.Body.Close()
 
 	bs, err := ioutil.ReadAll(instanceIdResp.Body)
 	if err != nil {
 		log.Error("ioutil.ReadAll instanceIdResp", "Error", err)
 		return err
 	}
-	instanceIdResp.Body.Close()
 
 	region, err := ioutil.ReadAll(awsRegionResp.Body)
 	if err != nil {
 		log.Error("ioutil.ReadAll awsRegionResp", "Error", err)
 		return err
 	}
-	awsRegionResp.Body.Close()
 	awsRegion := string(region)
 	//strip down the AZ char
 	awsRegion = awsRegion[:len(awsRegion)-1]

--- a/docs/detailed_design/config-reference.md
+++ b/docs/detailed_design/config-reference.md
@@ -15,6 +15,7 @@ For each field the following notation is used
 - [environments](#environments) (>=1!)
   - [name](#environment-name) (>=1!)
   - [stack_definition_path](#stack_definition_path) (==1?)
+  - [autowire_security_groups](#autowire_security_groups) (==1?)
   - [role_arn](#role_arn) (==1!)
   - [instance_count](#instance_count) (==1?)
   - [instance_type](#instance_type) (==1?)
@@ -149,6 +150,16 @@ CloudFormation stack definition file.
 
 The most specific definition is used meaning if it's defined on an environment
 and an environment's region, the region value will be used.
+
+### autowire_security_groups
+
+By default porter manages security groups to allow the provisioned ELB, and
+inspects the ELB that instances will be promoted into so that both ELBs can send
+traffic to EC2 instances.
+
+Set `autowire_security_groups: false` to disable this.
+
+This setting does not affect, and is not affected by, `security_group_egress`
 
 ### role_arn
 

--- a/docs/detailed_design/config-reference.md
+++ b/docs/detailed_design/config-reference.md
@@ -231,7 +231,7 @@ blackout_windows:
 
 ### hot_swap
 
-Opt into [hot swap deployments](#hotswap.md)
+Opt into [hot swap deployments](hotswap.md)
 
 ```yaml
 environments:

--- a/provision/ensure_resources.go
+++ b/provision/ensure_resources.go
@@ -65,16 +65,19 @@ func (recv *stackCreator) ensureResources(template *cfn.Template) (success bool)
 			return
 		}
 
-		if !recv.ensureDestinationELBSecurityGroup(template) {
-			return
-		}
+		if recv.environment.CreateSecurityGroups == nil || *recv.environment.CreateSecurityGroups == true {
 
-		if !recv.ensureInetToELBSG(template) {
-			return
-		}
+			if !recv.ensureDestinationELBSecurityGroup(template) {
+				return
+			}
 
-		if !recv.ensureProvisionedELBToInstanceSG(template) {
-			return
+			if !recv.ensureInetToELBSG(template) {
+				return
+			}
+
+			if !recv.ensureProvisionedELBToInstanceSG(template) {
+				return
+			}
 		}
 
 		if !recv.ensureDNSResources(template) {

--- a/util/retry.go
+++ b/util/retry.go
@@ -1,3 +1,14 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
 package util
 
 import (

--- a/util/retry_test.go
+++ b/util/retry_test.go
@@ -1,3 +1,14 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
 package util_test
 
 import (

--- a/util/suite_test.go
+++ b/util/suite_test.go
@@ -1,3 +1,14 @@
+/*
+ *  Copyright 2016 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ */
 package util_test
 
 import (


### PR DESCRIPTION
## Changelog

- add `autowire_security_groups` so security group management can be turned off

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A
