### PR TITLE
increase devicemapper base size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v3.1.0
+
+- increased devicemapper base size to 50GB
+
 ### v3.0.5
 
 - add `autowire_security_groups` so security group management can be turned off

--- a/files/porter_bootstrap
+++ b/files/porter_bootstrap
@@ -14,6 +14,7 @@ export LOG_DEBUG=1
 
 env
 adduser porter-docker -u {{ .ContainerUserUid }}
+echo 'OPTIONS="$OPTIONS --storage-opt dm.basesize=50G"' >> /etc/sysconfig/docker
 # CIS Docker Benchmark 1.11.0 2.13
 echo 'OPTIONS="$OPTIONS --disable-legacy-registry"' >> /etc/sysconfig/docker
 # CIS Docker Benchmark 1.11.0 2.1
@@ -21,6 +22,7 @@ echo 'OPTIONS="$OPTIONS --icc=false"' >> /etc/sysconfig/docker
 {{ if .InsecureRegistry -}}
 echo 'OPTIONS="$OPTIONS --insecure-registry={{ .InsecureRegistry }}"' >> /etc/sysconfig/docker
 {{ end -}}
+
 service haproxy start
 service docker restart
 docker version


### PR DESCRIPTION
## Changelog

- increased devicemapper base size to 50GB

[Reference](https://docs.docker.com/engine/reference/commandline/dockerd/#devicemapper-options)

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [ ] Yes
- [ ] N/A

