### PR TITLE
Don’t ignore package failures

### DIFF
--- a/commands/build/pack.go
+++ b/commands/build/pack.go
@@ -75,9 +75,12 @@ func doPack() (success bool) {
 
 	success = provision.Package(log, config)
 
-	if success {
-		log.Info("Packaged service", "FilePath", constants.PayloadPath)
+	if !success {
+		log.Error("Package failed")
+		return
 	}
+
+	log.Info("Packaged service", "FilePath", constants.PayloadPath)
 
 	success = true
 	return


### PR DESCRIPTION
## Changelog

- fixed `build pack` erroneously reporting success when the pack actually failed

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [ ] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [X] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [ ] Yes
- [X] N/A
