### PR TITLE
lock down egress by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ### v4.0.0
 
 - lock down ASG egress traffic to allow by default NTP, DNS, HTTP, and HTTPS
-- moved `security_group_egress` off of `auto_scaling_group`
-- `security_group_egress` rules additionally apply to the provisioned ELB
 - configurable haproxy header capture for logging
 
 ### v3.1.1

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -6,12 +6,47 @@ Read the [release notes](RELEASE_NOTES.md) for context on these changes.
 v3 to v4
 --------
 
+### Egress rules
+
+If you HAVE defined `security_group_egress` this is not a breaking change.
+
+If you HAVE NOT defined `security_group_egress` the default list is now
+
+```yaml
+security_group_egress:
+
+# allow all DNS
+- cidr_ip: 0.0.0.0/0
+  ip_protocol: udp
+  from_port: 53
+  to_port: 53
+
+# allow all NTP
+- cidr_ip: 0.0.0.0/0
+  ip_protocol: udp
+  from_port: 123
+  to_port: 123
+
+# allow all HTTP
+- cidr_ip: 0.0.0.0/0
+  ip_protocol: tcp
+  from_port: 80
+  to_port: 80
+
+# allow all HTTPS
+- cidr_ip: 0.0.0.0/0
+  ip_protocol: tcp
+  from_port: 443
+  to_port: 443
+```
+
+See the [`security_group_egress`](docs/detailed_design/config-reference.md#security_group_egress)
+config for more info.
+
 ### HAProxy request header captures
 
-**You must re-provision for these changes to take effect**
-
-The old config captured `X-Request-Id` for request and response, and
-`X-Forwarded-For` for the request.
+This is a breaking change for logging field extractions that expect to parse
+`X-Request-Id` or `X-Forwarded-For` in haproxy logs.
 
 This is a snippet of the old config
 
@@ -47,6 +82,8 @@ environments:
     - header: X-Request-Id
       length: 40
 ```
+
+**You must re-provision for these changes to take effect**
 
 See the [HAProxy docs](https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#8.8)
 for exactly where these end up in your logs

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -43,6 +43,10 @@ security_group_egress:
 See the [`security_group_egress`](docs/detailed_design/config-reference.md#security_group_egress)
 config for more info.
 
+Since egress rules are now added to every deployment the addition of
+`ec2:AuthorizeSecurityGroupEgress` and `ec2:RevokeSecurityGroupEgress` to the
+porter deployment policy are now required. They used to be optional.
+
 ### HAProxy request header captures
 
 This is a breaking change for logging field extractions that expect to parse

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,8 +10,8 @@ v4.0
 v4 - Egress rules
 -----------------
 
-For a number of security reasons porter now locks down ASG and ELB egress
-traffic to allow by default NTP (udp 123), DNS (udp 53), HTTP (tcp 80), and
+For a number of security reasons porter now locks down ASG egress traffic to
+allow by default NTP (udp 123), DNS (udp 53), HTTP (tcp 80), and
 HTTPS (tcp 443). You can still define your own egress rules using [`security_group_egress`](docs/detailed_design/config-reference.md#security_group_egress)
 or turn off porter's security group management entirely with
 [`autowire_security_groups: false`](docs/detailed_design/config-reference.md#autowire_security_groups)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ For a number of security reasons porter now locks down ASG egress traffic to
 allow by default NTP (udp 123), DNS (udp 53), HTTP (tcp 80), and
 HTTPS (tcp 443). You can still define your own egress rules using [`security_group_egress`](docs/detailed_design/config-reference.md#security_group_egress)
 or turn off porter's security group management entirely with
-[`autowire_security_groups: false`](docs/detailed_design/config-reference.md#autowire_security_groups)
+[`autowire_security_groups: false`](docs/detailed_design/config-reference.md#autowire_security_groups).
 
 v4 - HAProxy header capture
 ---------------------------

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -133,7 +133,7 @@ type (
 		ELBs                []*ELB             `yaml:"elbs"`
 		ELB                 string             `yaml:"elb"`
 		RoleARN             string             `yaml:"role_arn"`
-		AutoScalingGroup    *AutoScalingGroup  `yaml:"auto_scaling_group"`
+		AutoScalingGroup    AutoScalingGroup   `yaml:"auto_scaling_group"`
 		SSLCertARN          string             `yaml:"ssl_cert_arn"`
 		HostedZoneName      string             `yaml:"hosted_zone_name"`
 		KeyPairName         string             `yaml:"key_pair_name"`
@@ -217,6 +217,35 @@ func (recv *Config) SetDefaults() {
 		}
 
 		for _, region := range env.Regions {
+
+			if len(region.AutoScalingGroup.SecurityGroupEgress) == 0 {
+				region.AutoScalingGroup.SecurityGroupEgress = []SecurityGroupEgress{
+					{ // DNS
+						CidrIp:     "0.0.0.0/0",
+						IpProtocol: "udp",
+						FromPort:   53,
+						ToPort:     53,
+					},
+					{ // NTP
+						CidrIp:     "0.0.0.0/0",
+						IpProtocol: "udp",
+						FromPort:   123,
+						ToPort:     123,
+					},
+					{ // HTTP
+						CidrIp:     "0.0.0.0/0",
+						IpProtocol: "tcp",
+						FromPort:   80,
+						ToPort:     80,
+					},
+					{ // HTTPS
+						CidrIp:     "0.0.0.0/0",
+						IpProtocol: "tcp",
+						FromPort:   443,
+						ToPort:     443,
+					},
+				}
+			}
 
 			if region.ELB != "" {
 				if region.ELBs == nil {

--- a/docs/detailed_design/cfn-customization.md
+++ b/docs/detailed_design/cfn-customization.md
@@ -10,7 +10,7 @@ those resources. There are 2 major exception to this rule:
 1. For properties that are lists like EC2 tags and SecurityGroups porter only
    appends to these lists
 1. All the AutoScalingGroup's SecurityGroup's SecurityGroupEgress properties are
-   overwritten with secure defaults. For more on this see [`security_group_egress`](config-reference.md#security_group_egress)
+   overwritten with the value of [`security_group_egress`](config-reference.md#security_group_egress)
 
 Some simple examples are below. Porter injects various [CFN parameters](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)
 such as `PorterServiceName` and `PorterEnvironment`. Additionally there are a

--- a/docs/detailed_design/cfn-customization.md
+++ b/docs/detailed_design/cfn-customization.md
@@ -5,8 +5,12 @@ Porter allows services to define the subset of a CloudFormation (CFN) template
 that they want to be different than what porter creates by default.
 
 The basic rule is that porter won't alter defined resources and properties on
-those resources. There are some exceptions for properties that are lists (like
-EC2 tags).
+those resources. There are 2 major exception to this rule:
+
+1. For properties that are lists like EC2 tags and SecurityGroups porter only
+   appends to these lists
+1. All the AutoScalingGroup's SecurityGroup's SecurityGroupEgress properties are
+   overwritten with secure defaults. For more on this see [`security_group_egress`](config-reference.md#security_group_egress)
 
 Some simple examples are below. Porter injects various [CFN parameters](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html)
 such as `PorterServiceName` and `PorterEnvironment`. Additionally there are a
@@ -29,30 +33,10 @@ For all examples we'll use the following `.porter/config` and just change
 `.porter/cfn.json` in each example.
 
 ```yaml
-service_name: zero2porter
-
-porter_version: v0.61.1
-
-containers:
-- topology: inet
-
 environments:
-- name: PROD
+- name: dev
 
   stack_definition_path: .porter/cfn.json
-
-  regions:
-  - name: us-west-2
-    azs:
-    - name: us-west-2a
-    - name: us-west-2b
-    - name: us-west-2c
-
-    role_arn: arn:aws:iam::123456789012:role/zero2porter-deployment
-    s3_bucket: zero2porter-us-west-2
-
-    elb: zero2porter-prod
-
 ```
 
 Examples
@@ -62,9 +46,9 @@ Examples
 
 ### SSH
 
-This is probably the first customization every service operator needs, SSH
-access. Porter adds all the resources _not_ already defined in order to create a
-working CloudFormation template which means the
+This is probably the first customization you'll want as you begin to explore a
+porter deployment: SSH access. Porter adds all the resources _not_ already
+defined in order to create a working CloudFormation template which means the
 `AWS::AutoScaling::LaunchConfiguration` isn't overwritten, and security groups
 are added to the `SecurityGroups` property already defined.
 

--- a/provision/map_resource.go
+++ b/provision/map_resource.go
@@ -212,22 +212,18 @@ func overwriteASGSecurityGroupEgress(recv *stackCreator, template *cfn.Template,
 		securityGroups []interface{}
 	)
 
-	if recv.region.AutoScalingGroup == nil {
-		return true
-	}
-
 	if len(recv.region.AutoScalingGroup.SecurityGroupEgress) == 0 {
 		return true
 	}
 
 	if props, ok = resource["Properties"].(map[string]interface{}); !ok {
-		recv.log.Error("Missing Properties on resource")
-		return false
+		props = make(map[string]interface{})
+		resource["Properties"] = props
 	}
 
 	if securityGroups, ok = props["SecurityGroups"].([]interface{}); !ok {
-		recv.log.Error("Missing SecurityGroups on Properties")
-		return false
+		securityGroups = make([]interface{}, 0)
+		props["SecurityGroups"] = securityGroups
 	}
 
 	fn := func(securityGroup map[string]interface{}) bool {
@@ -237,19 +233,11 @@ func overwriteASGSecurityGroupEgress(recv *stackCreator, template *cfn.Template,
 		)
 
 		if props, ok = securityGroup["Properties"].(map[string]interface{}); !ok {
-			recv.log.Error("Missing Properties on SecurityGroup")
-			return false
+			props = make(map[string]interface{})
+			securityGroup["Properties"] = props
 		}
 
-		delete(props, "SecurityGroupEgress")
-		securityGroupEgress := make([]interface{}, 0)
-
-		for _, configEgress := range recv.region.AutoScalingGroup.SecurityGroupEgress {
-
-			securityGroupEgress = append(securityGroupEgress, configEgress)
-		}
-
-		props["SecurityGroupEgress"] = securityGroupEgress
+		props["SecurityGroupEgress"] = recv.region.AutoScalingGroup.SecurityGroupEgress
 		return true
 	}
 

--- a/provision/stack_creator_secrets.go
+++ b/provision/stack_creator_secrets.go
@@ -159,11 +159,6 @@ func (recv *stackCreator) getHostSecrets() (hostSecrets []byte, success bool) {
 	recv.log.Debug("getHostSecrets() BEGIN")
 	defer recv.log.Debug("getHostSecrets() END")
 
-	if recv.region.AutoScalingGroup == nil {
-		success = true
-		return
-	}
-
 	if recv.region.AutoScalingGroup.SecretsExecName == "" {
 		success = true
 		return


### PR DESCRIPTION
## Changelog

- lock down ASG egress traffic to allow by default NTP, DNS, HTTP, and HTTPS

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A

