### PR TITLE
delete failed stacks by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v4.0.0
 
+- failed stacks now delete instead of rollback
 - lock down ASG egress traffic to allow by default NTP, DNS, HTTP, and HTTPS
 - configurable haproxy header capture for logging
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,15 @@ v4 - HAProxy header capture
 Enabled configurable HAProxy header captures which make HAProxy logs more useful
 to those that weren't using UUIDv4 for `X-Request-Id`
 
+v4 - Failed stacks delete
+-------------------------
+
+The new default to the `OnFailure` parameter of `cloudformation:CreateStack` is
+`DELETE`.
+
+If the previous behavior is desired it can be set using `ON_STACK_FAILURE`. Run
+`porter help debug` for more
+
 v3.0
 ====
 

--- a/commands/help/debug.go
+++ b/commands/help/debug.go
@@ -19,39 +19,58 @@ import (
 const debugLongHelp = `These are various environment variable porter looks for to enable debugging in
 the field.
 
-Most of the DEBUG_ flags cause additional logs to be sent via stdout.
+The DEBUG_ flags cause additional logs to be sent via stdout.
 
 The value for these flags is a non-empty string unless otherwise noted.
 
 DEBUG_CONFIG
+
     Print out configuration
 
     Example:
     DEBUG_CONFIG=1 porter create-stack -e dev
 
 DEBUG_AWS
+
     Dump all AWS HTTP calls
 
 LOG_DEBUG
+
     Turn on porter's debug logging
 
 LOG_COLOR
+
     Turn on log colors
 
 STACK_CREATION_TIMEOUT
-    Override rollback time with a string parsed by
+
+    Override rollback time with a string parsed by time.ParseDuration()
     https://golang.org/pkg/time/#ParseDuration
 
-    This is clamped to the min and max duration supported by STS AssumeRole
+    This is clamped to the min and max duration supported by sts:AssumeRole
 
     Example:
     export STACK_CREATION_TIMEOUT=1h
     porter create-stack -e dev
 
 STACK_CREATION_POLL_INTERVAL
+
     Override the default polling for creation status interval during
-    stack provisioning. The value is a string parsed by
-    https://golang.org/pkg/time/#ParseDuration. The default value is 10 seconds.
+    stack provisioning. The value is a string parsed by time.ParseDuration()
+    The default value is 10 seconds.
+
+    https://golang.org/pkg/time/#ParseDuration
+
+STACK_CREATION_ON_FAILURE
+
+    By default porter calls cloudformation:CreateStack with OnFailure = DELETE
+
+    Set this to DO_NOTHING or ROLLBACK to change this behavior. ROLLBACK is
+    often useful for examining CloudFormation events to see if resources failed
+    to provision. DO_NOTHING can give you time to login to an EC2 host if the
+    WaitCondition failed to complete
+
+    http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html
 
 DEV_MODE
     Grease the wheels on development`

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -38,7 +38,7 @@ const (
 	EnvStackCreation             = "STACK_CREATION_TIMEOUT"
 	EnvStackCreationPollInterval = "STACK_CREATION_POLL_INTERVAL"
 	EnvDevMode                   = "DEV_MODE"
-	EnvConfigPath                = "CONFIG_PATH"
+	EnvStackCreationOnFailure    = "STACK_CREATION_ON_FAILURE"
 
 	// Registry-based deployment
 	EnvDockerRegistry         = "DOCKER_REGISTRY"
@@ -48,6 +48,9 @@ const (
 	EnvDockerPullPassword     = "DOCKER_PULL_PASSWORD"
 	EnvDockerPushUsername     = "DOCKER_PUSH_USERNAME"
 	EnvDockerPushPassword     = "DOCKER_PUSH_PASSWORD"
+
+	// Host
+	EnvConfigPath = "CONFIG_PATH"
 
 	HookPrePack       = "pre_pack"
 	HookPostPack      = "post_pack"


### PR DESCRIPTION
## Changelog

- cloudformation:CreateStack `OnFailure = DELETE` by default

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [ ] Yes
- [x] N/A

