### PR TITLE
SecurityGroups can be a list of sg-ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v4.0.1
+
+- fix type assertion for sg-ids that are statically defined
+
 ### v4.0.0
 
 - failed stacks now delete instead of rollback

--- a/provision/map_resource.go
+++ b/provision/map_resource.go
@@ -243,6 +243,8 @@ func overwriteASGSecurityGroupEgress(recv *stackCreator, template *cfn.Template,
 
 	logicalNameToSecurityGroup := template.GetResourcesByType(cfn.EC2_SecurityGroup)
 
+	// securityGroupRaw may be a string referencing a sg-id that isn't part of
+	// the cloudformation stack
 	for _, securityGroupRaw := range securityGroups {
 
 		if securityGroupMsi, ok := securityGroupRaw.(map[string]interface{}); ok {
@@ -265,10 +267,6 @@ func overwriteASGSecurityGroupEgress(recv *stackCreator, template *cfn.Template,
 					return false
 				}
 			}
-		} else {
-
-			recv.log.Error("SecurityGroup type assertion failed")
-			return false
 		}
 	}
 


### PR DESCRIPTION
## Changelog

- fix type assertion for sg-ids that are statically defined

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [ ] Yes
- [x] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [ ] Yes
- [x] N/A

