### PR TITLE
ASG size matching only occurs when opted into hot swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v4.1.1
+
+- ASG size matching only occurs when `hot_swap: true`
+
 ### v4.1.0
 
 - configurable instance count per region

--- a/provision/api.go
+++ b/provision/api.go
@@ -78,7 +78,7 @@ func CreateStack(log log15.Logger, config *conf.Config, stack *provision_state.S
 		return
 	}
 
-	return createUpdateStack(log, stack, config, cfnAPI)
+	return createUpdateStack(log, stack, config, false, cfnAPI)
 }
 
 func UpdateStack(log log15.Logger, config *conf.Config, stack provision_state.Stack) bool {
@@ -123,13 +123,14 @@ func UpdateStack(log log15.Logger, config *conf.Config, stack provision_state.St
 		return
 	}
 
-	return createUpdateStack(log, &stack, config, cfnAPI)
+	return createUpdateStack(log, &stack, config, true, cfnAPI)
 }
 
 func createUpdateStack(
 	log log15.Logger,
 	stack *provision_state.Stack,
 	config *conf.Config,
+	updateStack bool,
 	cfnAPI func(*cfnlib.CloudFormation, CfnApiInput) (string, bool)) (success bool) {
 
 	environment, err := config.GetEnvironment(stack.Environment)
@@ -163,7 +164,8 @@ func createUpdateStack(
 
 			roleSession: roleSession,
 
-			cfnAPI: cfnAPI,
+			cfnAPI:      cfnAPI,
+			updateStack: updateStack,
 
 			templateTransforms: make(map[string][]MapResource),
 		}

--- a/provision_state/provision_state.go
+++ b/provision_state/provision_state.go
@@ -26,8 +26,6 @@ type (
 		ProvisionedELBName string
 
 		// info on currently promoted stack
-		AsgMin     int `json:"-"`
 		AsgDesired int `json:"-"`
-		AsgMax     int `json:"-"`
 	}
 )


### PR DESCRIPTION
## Changelog

- ASG size matching only occurs when `hot_swap: true`

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A

