### PR TITLE
Misc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### v4.2.0
 
 - HAProxy stats endpoint auth is now randomized
+- re-enabled keep-alive between HAProxy and containers
+- building on go 1.8
+- added STANDARD_IA to secrets and CFN template uploads
 
 ### v4.1.1
 

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.8.0
 
 ADD . /go/src/github.com/adobe-platform/porter
 WORKDIR /go/src/github.com/adobe-platform/porter

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.7.3
+FROM golang:1.8.0
 
 RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/onsi/gomega

--- a/files/haproxy.cfg
+++ b/files/haproxy.cfg
@@ -34,17 +34,8 @@ defaults
   timeout client 3600s
   timeout server 3600s
 
-  # Do not maintain a Keep-Alive connection to the backend so we can cleanup
-  # containers after a hotswap. Even with no active frontend connections to
-  # HAProxy, HAProxy will maintain a few connections to the backend.
-  option http-server-close
-
 frontend {{ .ServiceName }}-frontend
 
-  # Bind to all interfaces
-  # TODO constrain this to eth0 and lo?
-  # I'm not sure what security holes could be exploited by binding to all
-  # available interfaces
 {{- range $port := .FrontEndPorts }}
   bind *:{{ $port -}}
 {{ end }}

--- a/files/porter_bootstrap
+++ b/files/porter_bootstrap
@@ -69,6 +69,9 @@ sysctl -w net.ipv4.ip_local_reserved_ports='8080'
 # https://github.com/torvalds/linux/blob/v4.1/Documentation/networking/ip-sysctl.txt#L1021
 sysctl -w net.ipv4.conf.all.rp_filter=1
 
+# https://github.com/torvalds/linux/blob/v4.1/Documentation/networking/ip-sysctl.txt#L488
+sysctl -w net.ipv4.tcp_slow_start_after_idle=0
+
 # A hotswap operation is identical to what happens during initial configuration
 echo "installing service payload"
 /usr/bin/porter_hotswap

--- a/provision/stack_creator.go
+++ b/provision/stack_creator.go
@@ -431,10 +431,11 @@ func (recv *stackCreator) createStack() (stackId string, success bool) {
 	templateS3Key := fmt.Sprintf("%s/%s", recv.s3KeyRoot(s3KeyOptTemplate), checksum)
 
 	uploadInput := &s3manager.UploadInput{
-		Bucket:      aws.String(recv.region.S3Bucket),
-		Key:         aws.String(templateS3Key),
-		Body:        bytes.NewReader(templateBytes),
-		ContentType: aws.String("application/json"),
+		Bucket:       aws.String(recv.region.S3Bucket),
+		Key:          aws.String(templateS3Key),
+		Body:         bytes.NewReader(templateBytes),
+		ContentType:  aws.String("application/json"),
+		StorageClass: aws.String("STANDARD_IA"),
 	}
 
 	if recv.region.SSEKMSKeyId != nil {

--- a/provision/stack_creator_secrets.go
+++ b/provision/stack_creator_secrets.go
@@ -227,9 +227,10 @@ func (recv *stackCreator) uploadSecrets(checksum string) (success bool) {
 	}
 
 	uploadInput := &s3manager.UploadInput{
-		Bucket: aws.String(recv.region.S3Bucket),
-		Key:    aws.String(recv.secretsLocation),
-		Body:   bytes.NewReader(secretPayloadBytesEnc),
+		Bucket:       aws.String(recv.region.S3Bucket),
+		Key:          aws.String(recv.secretsLocation),
+		Body:         bytes.NewReader(secretPayloadBytesEnc),
+		StorageClass: aws.String("STANDARD_IA"),
 	}
 
 	if recv.region.SSEKMSKeyId != nil {

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -1,3 +1,14 @@
+/*
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
 package secrets
 
 import (


### PR DESCRIPTION
## Changelog

- re-enabled keep-alive between HAProxy and containers
- building on go 1.8
- added STANDARD_IA to secrets and CFN template uploads

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A
