### PR TITLE
haproxy configurable log and compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v4.5.0
+
+- added opt-in HAProxy compression
+- added configurable list of MIME types to compress
+- HAProxy logs can be turned off
+
 ### v4.4.0
 
 - disabled userland proxy

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,11 @@ See the [CHANGELOG](CHANGELOG.md) for a complete list of changes.
 
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+v4.5
+====
+
+Exposed HAProxy configuration to adjust logging and compression.
+
 v4.4
 ====
 

--- a/commands/host/haproxy.go
+++ b/commands/host/haproxy.go
@@ -44,6 +44,9 @@ type (
 		StatsPassword     string
 		StatsUri          string
 		IpBlacklistPath   string
+		Log               bool
+		Compression       bool
+		CompressTypes     string
 		ReqHeaderCaptures []conf.HeaderCapture
 		ResHeaderCaptures []conf.HeaderCapture
 	}
@@ -176,6 +179,9 @@ func hotswap(log log15.Logger, environmentStr, regionStr string, hapStdin HAPStd
 		StatsPassword:     config.HAProxyStatsPassword,
 		StatsUri:          constants.HAProxyStatsUri,
 		IpBlacklistPath:   ipBlacklistPath,
+		Log:               (environment.HAProxy.Log == nil || *environment.HAProxy.Log == true),
+		Compression:       environment.HAProxy.Compression,
+		CompressTypes:     strings.Join(environment.HAProxy.CompressTypes, " "),
 		ReqHeaderCaptures: environment.HAProxy.ReqHeaderCaptures,
 		ResHeaderCaptures: environment.HAProxy.ResHeaderCaptures,
 	}

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -116,6 +116,9 @@ type (
 		// Capture headers for logging
 		ReqHeaderCaptures []HeaderCapture `yaml:"request_header_captures"`
 		ResHeaderCaptures []HeaderCapture `yaml:"response_header_captures"`
+		Log               *bool           `yaml:"log"`
+		Compression       bool            `yaml:"compression"`
+		CompressTypes     []string        `yaml:"compress_types"`
 	}
 
 	HeaderCapture struct {
@@ -218,6 +221,10 @@ func (recv *Config) SetDefaults() {
 
 		if env.InstanceType == "" {
 			env.InstanceType = "m3.medium"
+		}
+
+		if len(env.HAProxy.CompressTypes) > 0 {
+			env.HAProxy.Compression = true
 		}
 
 		for _, region := range env.Regions {

--- a/docs/detailed_design/config-reference.md
+++ b/docs/detailed_design/config-reference.md
@@ -21,7 +21,12 @@ For each field the following notation is used
   - [instance_type](#instance_type) (==1?)
   - [blackout_windows](#blackout_windows) (>=1?)
   - [hot_swap](#hot_swap) (==1?)
-  - [haproxy](#haproxy) (==1?)
+  - [haproxy](==1?)
+    - [request_header_captures](#header-captures) (>=1?)
+    - [response_header_captures](#header-captures) (>=1?)
+    - [log](#log) (==1?)
+    - [compression](#compression) (==1?)
+    - [compress_types](#compress_types) (==1?)
   - [regions](#regions) (>=1!)
     - [name](#region-name) (==1!)
     - [stack_definition_path](#stack_definition_path) (==1?)
@@ -252,7 +257,7 @@ environments:
   hot_swap: true
 ```
 
-### haproxy
+### header-captures
 
 Header captures can be defined. See the [HAProxy docs](https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#8.8)
 for more about how to parse these logs.
@@ -270,6 +275,44 @@ environments:
     response_header_captures:
     - header: X-Request-Id
       length: 40
+```
+
+### log
+
+Turn off HAProxy logs which saves CPU cycles
+
+```yaml
+environments:
+- name: dev
+  haproxy:
+    log: false
+```
+
+### compression
+
+Turn on gzip compression.
+
+If no [`compress_types`](#compress_types) are defined all responses are
+compressed.
+
+```yaml
+environments:
+- name: dev
+  haproxy:
+    compression: true
+```
+
+### compress_types
+
+List of MIME types to compress.
+
+Any value here implies [`compression: true`](#compression)
+
+```yaml
+environments:
+- name: dev
+  haproxy:
+    compress_types: text/plain text/html application/json
 ```
 
 ### regions

--- a/files/haproxy.cfg
+++ b/files/haproxy.cfg
@@ -12,8 +12,12 @@ global
 defaults
   log global
   mode  http
+{{- if .Log }}
   option  httplog
   option  dontlognull
+{{- else }}
+  no log
+{{- end }}
   retries 3
   option redispatch
 
@@ -33,6 +37,13 @@ defaults
   # Without the knowledge that our client is ELB this value doesn't make sense
   timeout client 3600s
   timeout server 3600s
+
+{{ if .Compression }}
+  compression algo gzip
+{{- end }}
+{{- if .CompressTypes }}
+  compression type {{ .CompressTypes }}
+{{- end }}
 
 frontend {{ .ServiceName }}-frontend
 


### PR DESCRIPTION
## Changelog

- added opt-in HAProxy compression
- added configurable list of MIME types to compress
- HAProxy logs can be turned off

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A
