### PR TITLE
maxconn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v4.9.0
+
+- HAProxy `maxconn` is configurable
+- fixed issue where `maxconn` wasn't set on the frontend
+
 ### v4.8.3
 
 - enabling fix for volume mounts on SELinux by setting the environment variable `VOLUME_FLAG`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,12 @@ See the [CHANGELOG](CHANGELOG.md) for a complete list of changes.
 
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+v4.9
+====
+
+HAProxy's [`maxconn`](docs/detailed_design/config-reference.md#maxconn)
+is now configurable.
+
 v4.8
 ====
 

--- a/commands/host/haproxy.go
+++ b/commands/host/haproxy.go
@@ -52,6 +52,7 @@ type (
 		ResHeaderCaptures []conf.HeaderCapture
 		HTTPS_Redirect    bool
 		HaveELB           bool
+		MaxConn           uint64
 
 		TimeoutClient        uint64
 		TimeoutServer        uint64
@@ -225,6 +226,7 @@ func hotswap(log log15.Logger, environmentStr, regionStr string, hapStdin HAPStd
 		ResHeaderCaptures:    environment.HAProxy.ResHeaderCaptures,
 		HTTPS_Redirect:       environment.HAProxy.SSL.HTTPS_Redirect,
 		HaveELB:              region.HasELB(),
+		MaxConn:              environment.HAProxy.MaxConn,
 		TimeoutClient:        uint64(environment.HAProxy.Timeout.Client_.Seconds() * 1000),
 		TimeoutServer:        uint64(environment.HAProxy.Timeout.Server_.Seconds() * 1000),
 		TimeoutTunnel:        uint64(environment.HAProxy.Timeout.Tunnel_.Seconds() * 1000),

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -124,6 +124,7 @@ type (
 		CompressTypes     []string        `yaml:"compress_types"`
 		SSL               SSL             `yaml:"ssl"`
 		Timeout           Timeout         `yaml:"timeout"`
+		MaxConn           uint64          `yaml:"maxconn"`
 	}
 
 	Timeout struct {
@@ -265,6 +266,10 @@ func (recv *Config) SetDefaults() {
 
 		if env.HAProxy.SSL.CertDirectory == "" {
 			env.HAProxy.SSL.CertDirectory = "/etc/ssl/certs/"
+		}
+
+		if env.HAProxy.MaxConn == 0 {
+			env.HAProxy.MaxConn = 200000
 		}
 
 		if env.HAProxy.Timeout.Client == nil || *env.HAProxy.Timeout.Client == "" {

--- a/docs/detailed_design/config-reference.md
+++ b/docs/detailed_design/config-reference.md
@@ -28,6 +28,7 @@ For each field the following notation is used
     - [compression](#compression) (==1?)
     - [compress_types](#compress_types) (==1?)
     - [timeout](#timeout)
+    - [maxconn](#maxconn) (==1?)
     - [ssl](#ssl) (==1?)
       - [cert_directory](#cert_directory) (==1?)
       - [pem](#pem) (==?!)
@@ -355,6 +356,13 @@ Disable any timeout by setting the value to `0`
 
 Refer to the [HAProxy docs](https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#4.2-timeout%20client)
 for what these timeouts mean
+
+### maxconn
+
+[`maxconn`](https://cbonte.github.io/haproxy-dconv/1.5/configuration.html#4-maxconn)
+docs. This sets `maxconn` in the global and defaults sections.
+
+Default: `200000`
 
 ### ssl
 

--- a/files/haproxy.cfg
+++ b/files/haproxy.cfg
@@ -6,8 +6,7 @@ global
   daemon
 
   # NOTE: this only sets ulimit, not 'sysctl fs.file-max' which may need tuned
-  # TODO calculate this
-  maxconn 200000
+  maxconn {{ .MaxConn }}
 
 defaults
   log global
@@ -20,6 +19,7 @@ defaults
 {{- end }}
   retries 3
   option redispatch
+  maxconn {{ .MaxConn }}
 
   # Time to connect to backends
   # N * 3 + 1 where N=4 was chosen based on load testing


### PR DESCRIPTION
## Changelog

- configurable haproxy `maxconn`
- fixed issue where `maxconn` wasn't set on the frontend

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A
