### PR TITLE
R2 remediations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v5.0.0
+
+- upgrade to Go 1.9.2
+
 ### v4.9.0
 
 - HAProxy `maxconn` is configurable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v5.0.0
 
 - upgrade to Go 1.9.2
+- default to `--pids-limit=4096`
 
 ### v4.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v5.0.0
 
-- upgrade to Go 1.9.2
+- build porter with Go 1.9.2
 - default to `--pids-limit=4096`
 
 ### v4.9.0
@@ -61,7 +61,7 @@
 
 - HAProxy stats endpoint auth is now randomized
 - re-enabled keep-alive between HAProxy and containers
-- building on go 1.8
+- build porter with Go 1.8
 - added STANDARD_IA to secrets and CFN template uploads
 
 ### v4.1.1
@@ -110,7 +110,7 @@
 
 - additional UPDATE steady states allow ASG matching
 - any UPDATE in progress state causes hot swap to fail
-- mac binaries are now built with Go 1.7.3
+- build porter with Go 1.7.3
 - match currently promoted stack's ASG size for provisioning and hot swap
 
 ### v3.0.1

--- a/Dockerfile.godep
+++ b/Dockerfile.godep
@@ -1,3 +1,3 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 RUN go get github.com/tools/godep

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 ADD . /go/src/github.com/adobe-platform/porter
 WORKDIR /go/src/github.com/adobe-platform/porter

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/onsi/gomega

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -3,6 +3,12 @@ Migration
 
 Read the [release notes](RELEASE_NOTES.md) for context on these changes.
 
+v4 to v5
+--------
+
+No migration steps are needed unless you hit
+[`pids_limit`](docs/detailed_design/config-reference.md#pids_limit)
+
 v3 to v4
 --------
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,19 @@ See the [CHANGELOG](CHANGELOG.md) for a complete list of changes.
 
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+v5.0
+====
+
+`docker run` now includes a default `--pids-limit=4096` to protect against fork
+bombs
+
+This shouldn't be a breaking change for normal applications but it's possible
+which is why there's a major version bump.
+
+`--pids-limit` can't be disabled but can be increased from the default by
+defining [`pids_limit`](docs/detailed_design/config-reference.md#pids_limit)
+on the `container`
+
 v4.9
 ====
 

--- a/commands/build/promote.go
+++ b/commands/build/promote.go
@@ -59,7 +59,7 @@ func (recv *PromoteCmd) SubCommands() []cli.Command {
 }
 
 func (recv *PromoteCmd) Execute(args []string) bool {
-	var provisionOutputPath, elbType string
+	var provisionOutputPath, elbTag string
 
 	if len(args) == 1 && args[0] == "--help" {
 		return false
@@ -67,7 +67,7 @@ func (recv *PromoteCmd) Execute(args []string) bool {
 
 	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
 	flagSet.StringVar(&provisionOutputPath, "provision-output", "", "")
-	flagSet.StringVar(&elbType, "elb", "", "")
+	flagSet.StringVar(&elbTag, "elb", "", "")
 	flagSet.Parse(args)
 
 	if provisionOutputPath == "" {
@@ -94,7 +94,7 @@ func (recv *PromoteCmd) Execute(args []string) bool {
 		return true
 	}
 
-	if !doPromote(log, stack, elbType) {
+	if !doPromote(log, stack, elbTag) {
 		os.Exit(1)
 	}
 

--- a/commands/host/docker.go
+++ b/commands/host/docker.go
@@ -209,6 +209,9 @@ func startContainers(environmentStr, regionStr string) {
 
 			"--net", "porter",
 
+			// prevent fork bombs
+			"--pids-limit", strconv.Itoa(container.PidsLimit),
+
 			// Read in additional variables written during bootstrap
 			"--env-file", constants.EnvFile,
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -81,6 +81,7 @@ type (
 		DockerfileBuild string       `yaml:"dockerfile_build"`
 		HealthCheck     *HealthCheck `yaml:"health_check"`
 		SrcEnvFile      *SrcEnvFile  `yaml:"src_env_file"`
+		PidsLimit       int          `yaml:"pids_limit"`
 	}
 
 	SrcEnvFile struct {
@@ -363,6 +364,10 @@ func (recv *Config) SetDefaults() {
 				}
 				if container.DockerfileBuild == "" {
 					container.DockerfileBuild = "Dockerfile.build"
+				}
+
+				if container.PidsLimit == 0 {
+					container.PidsLimit = 4096
 				}
 
 				if container.Topology == Topology_Inet {

--- a/conf/environment.go
+++ b/conf/environment.go
@@ -17,25 +17,26 @@ import (
 	"time"
 )
 
-func (recv *Environment) GetELBForRegion(reg string, elb string) (string, error) {
+func (recv *Environment) GetELBForRegion(reg string, elbTag string) (string, error) {
 	region, err := recv.GetRegion(reg)
 	if err != nil {
 		return "", err
 	}
 
-	// always return this if defined. it supersedes the old scheme
-	if region.ELB != "" {
-		return region.ELB, nil
-	}
-
 	// backward compatibility with old scheme
 	for _, loadBalancer := range region.ELBs {
-		if loadBalancer.ELBTag == elb {
+		if loadBalancer.ELBTag == elbTag {
 			return loadBalancer.Name, nil
 		}
 	}
 
-	return "", fmt.Errorf("ELB tagged %s doesn't exist in the config for region %s", elb, reg)
+	// elbTag will most often be "" so fall through
+	// to untagged single ELB if defined
+	if region.ELB != "" {
+		return region.ELB, nil
+	}
+
+	return "", fmt.Errorf("ELB tagged %s doesn't exist in the config for region %s", elbTag, reg)
 }
 
 func (recv *Environment) GetRegion(regionName string) (*Region, error) {

--- a/conf/validate.go
+++ b/conf/validate.go
@@ -334,6 +334,10 @@ func (recv *Region) ValidateContainers() error {
 			}
 		}
 
+		if container.PidsLimit < -1 {
+			return errors.New("pids_limit less than -1")
+		}
+
 		if containerCount > 1 && !containerNameRegex.MatchString(container.Name) {
 			return errors.New("Invalid container name")
 		}

--- a/conf/validate.go
+++ b/conf/validate.go
@@ -334,8 +334,8 @@ func (recv *Region) ValidateContainers() error {
 			}
 		}
 
-		if container.PidsLimit < -1 {
-			return errors.New("pids_limit less than -1")
+		if container.PidsLimit < 1 {
+			return errors.New("pids_limit must be greater than or equal to 1")
 		}
 
 		if containerCount > 1 && !containerNameRegex.MatchString(container.Name) {

--- a/docs/detailed_design/config-reference.md
+++ b/docs/detailed_design/config-reference.md
@@ -63,6 +63,7 @@ For each field the following notation is used
       - [read_only](#read_only) (==1?)
       - [health_check](#health_check) (==1?)
       - [src_env_file](#src_env_file) (==1?)
+      - [pids_limit](#pids_limit) (==1?)
 - [hooks](#hooks) (==1?)
   - pre_pack (==1?)
     - [repo](#repo) (==1!)
@@ -719,6 +720,12 @@ health_check:
 
 See the docs on [container config](container-config.md) for more info on this
 field
+
+### pids_limit
+
+Set `--pids-limit` on the container.
+
+The default is 4096.
 
 ### hooks
 

--- a/promote/promote.go
+++ b/promote/promote.go
@@ -29,7 +29,7 @@ const (
 	pollDuration  = 10 * time.Minute
 )
 
-func Promote(log log15.Logger, config *conf.Config, stack *provision_state.Stack, elb string) (success bool) {
+func Promote(log log15.Logger, config *conf.Config, stack *provision_state.Stack, elbTag string) (success bool) {
 
 	successChan := make(chan bool)
 
@@ -38,7 +38,7 @@ func Promote(log log15.Logger, config *conf.Config, stack *provision_state.Stack
 		go func(regionName string, regionState *provision_state.Region) {
 
 			successChan <- promoteService(log, stack.Environment, regionName,
-				regionState, config, elb)
+				regionState, config, elbTag)
 
 		}(regionName, regionState)
 	}

--- a/sample_project/Dockerfile.build
+++ b/sample_project/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 ADD . /go/src/github.com/adobe-platform/sample_project
 WORKDIR /go/src/github.com/adobe-platform/sample_project

--- a/testintegration/Dockerfile.inet.build
+++ b/testintegration/Dockerfile.inet.build
@@ -1,4 +1,4 @@
-FROM golang:1.8.1
+FROM golang:1.9.2
 
 ADD . /go/src/github.com/adobe-platform/porter_test
 WORKDIR /go/src/github.com/adobe-platform/porter_test


### PR DESCRIPTION
## Changelog

- build porter with Go 1.9.2
- default to `--pids-limit=4096`

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A
