### PR TITLE
region and instance type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+### v5.1.0
+
+- build porter with Go 1.10.1
+- regex matching on region names and instance types instead of whitelist
+
 ### v5.0.0
 
 - build porter with Go 1.9.2

--- a/Dockerfile.godep
+++ b/Dockerfile.godep
@@ -1,3 +1,3 @@
-FROM golang:1.9.2
+FROM golang:1.10.1
 
 RUN go get github.com/tools/godep

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM golang:1.9.2
+FROM golang:1.10.1
 
 ADD . /go/src/github.com/adobe-platform/porter
 WORKDIR /go/src/github.com/adobe-platform/porter

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.9.2
+FROM golang:1.10.1
 
 RUN go get github.com/onsi/ginkgo/ginkgo
 RUN go get github.com/onsi/gomega

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,11 @@ See the [CHANGELOG](CHANGELOG.md) for a complete list of changes.
 
 `porter` is [semantically versioned](http://semver.org/spec/v2.0.0.html)
 
+v5.1
+====
+
+Removed whitelisting on AWS Regions and EC2 Instance types.
+
 v5.0
 ====
 

--- a/conf/conf.go
+++ b/conf/conf.go
@@ -50,6 +50,8 @@ var (
 	vpcIdRegex           = regexp.MustCompile(`^vpc-(\d|\w){8}$`)
 	subnetIdRegex        = regexp.MustCompile(`^subnet-(\d|\w){8}$`)
 	commonNameRegex      = regexp.MustCompile(`^(\w+\.)?[a-z]+$`)
+	regionRegex          = regexp.MustCompile(`^[a-z]{2}-[a-z]+-\d$`)
+	instanceTypeRegex    = regexp.MustCompile(`^[a-z0-9]{2}\.[a-z0-9]+$`)
 
 	// https://github.com/docker/docker/blob/v1.11.2/utils/names.go#L6
 	// minus '-' which is reserved

--- a/conf/validate.go
+++ b/conf/validate.go
@@ -179,7 +179,7 @@ func (recv *Config) ValidateEnvironments() error {
 			}
 		}
 
-		if _, exists := constants.AwsInstanceTypes[environment.InstanceType]; !exists {
+		if !instanceTypeRegex.MatchString(environment.InstanceType) {
 			return errors.New("Invalid instance_type for environment [" + environment.Name + "]")
 		}
 
@@ -247,7 +247,7 @@ func ValidateRegion(region *Region, validateRoleArn bool) error {
 		return err
 	}
 
-	if _, exists := constants.AwsRegions[region.Name]; !exists {
+	if !regionRegex.MatchString(region.Name) {
 		return errors.New("Invalid region name " + region.Name)
 	}
 

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -155,8 +155,7 @@ const (
 )
 
 var (
-	AwsRegions       map[string]interface{}
-	AwsInstanceTypes map[string]interface{}
+	AwsRegions map[string]interface{}
 )
 
 func StackCreationTimeout() time.Duration {
@@ -196,55 +195,5 @@ func init() {
 		"us-east-1":      nil,
 		"us-west-1":      nil,
 		"us-west-2":      nil,
-	}
-
-	AwsInstanceTypes = map[string]interface{}{
-		"t2.nano":    nil,
-		"t2.micro":   nil,
-		"t2.small":   nil,
-		"t2.medium":  nil,
-		"t2.large":   nil,
-		"t2.xlarge":  nil,
-		"t2.2xlarge": nil,
-
-		"m4.large":    nil,
-		"m4.xlarge":   nil,
-		"m4.2xlarge":  nil,
-		"m4.4xlarge":  nil,
-		"m4.10xlarge": nil,
-		"m4.16xlarge": nil,
-
-		"m3.medium":  nil,
-		"m3.large":   nil,
-		"m3.xlarge":  nil,
-		"m3.2xlarge": nil,
-
-		"c4.large":   nil,
-		"c4.xlarge":  nil,
-		"c4.2xlarge": nil,
-		"c4.4xlarge": nil,
-		"c4.8xlarge": nil,
-
-		"c3.large":   nil,
-		"c3.xlarge":  nil,
-		"c3.2xlarge": nil,
-		"c3.4xlarge": nil,
-		"c3.8xlarge": nil,
-
-		"x1.32xlarge": nil,
-		"x1.16xlarge": nil,
-
-		"r4.large":    nil,
-		"r4.xlarge":   nil,
-		"r4.2xlarge":  nil,
-		"r4.4xlarge":  nil,
-		"r4.8xlarge":  nil,
-		"r4.16xlarge": nil,
-
-		"r3.large":   nil,
-		"r3.xlarge":  nil,
-		"r3.2xlarge": nil,
-		"r3.4xlarge": nil,
-		"r3.8xlarge": nil,
 	}
 }


### PR DESCRIPTION
## Changelog

- build porter with Go 1.10.1
- regex matching on region names and instance types instead of whitelist

Closes #186 

## Issues fixed or closed

## Questions (open the PR then click the check boxes)

Did you update the documentation related to your changes?

- [x] Yes
- [ ] My changes were not already documented

Did you run `make` _before_ committing code and opening this PR?

- [x] Yes
- [ ] I didn't change any code

Did you run `porter create-stack` and `porter sync-stack` to verify provisioning
works?

- [x] Yes
- [ ] N/A
